### PR TITLE
fix: Adiciona payment_method à interface IOrder

### DIFF
--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -183,6 +183,7 @@ export interface IOrder {
   final_amount: number;
   promotion_id: string;
   discount_amount: number;
+  payment_method?: string;
   services: [
     {
       service_id: string;


### PR DESCRIPTION
Corrige erro de TypeScript no DetailsOrder que estava tentando acessar payment_method que não existia na interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)